### PR TITLE
Make the BelongsToManyMultiSelect fields can be able to preload and fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,11 @@ php artisan vendor:publish --provider="Spatie\Permission\PermissionServiceProvid
 
 Now you should add any other configurations needed for the Spatie-Permission package.
 
+You can publish the config file of the package with:
+```bash
+php artisan vendor:publish --tag="filament-spatie-roles-permissions-config"
+```
+
 ## Usage
 
 You can add this to your *form* method in your UserResource 

--- a/config/config.php
+++ b/config/config.php
@@ -1,8 +1,0 @@
-<?php
-
-/*
- * You can place your custom package configuration in here.
- */
-return [
-
-];

--- a/config/filament-spatie-roles-permissions.php
+++ b/config/filament-spatie-roles-permissions.php
@@ -1,0 +1,9 @@
+<?php
+
+return [
+
+    'preload_roles' => false,
+
+    'preload_permissions' => false,
+
+];

--- a/resources/lang/en/filament-spatie.php
+++ b/resources/lang/en/filament-spatie.php
@@ -10,7 +10,7 @@ return [
     'field.guard_name' => 'Guard Name',
     'field.name' => 'Name',
     'field.permissions' => 'Permissions',
-    'field.roles' => 'roles',
+    'field.roles' => 'Roles',
 
     /*
     |--------------------------------------------------------------------------

--- a/src/FilamentSpatieRolesPermissionsServiceProvider.php
+++ b/src/FilamentSpatieRolesPermissionsServiceProvider.php
@@ -6,12 +6,22 @@ use Althinect\FilamentSpatieRolesPermissions\Resources\PermissionResource;
 use Althinect\FilamentSpatieRolesPermissions\Resources\RoleResource;
 use Filament\PluginServiceProvider;
 use Illuminate\Support\ServiceProvider;
+use Spatie\LaravelPackageTools\Package;
 
 class FilamentSpatieRolesPermissionsServiceProvider extends PluginServiceProvider
 {
     public static string $name = 'filament-spatie-roles-permissions';
 
-    protected function getResources() :array {
+    public function configurePackage(Package $package): void
+    {
+        $package
+            ->name('filament-spatie-roles-permissions')
+            ->hasConfigFile()
+            ->hasTranslations();
+    }
+
+    protected function getResources(): array
+    {
         return [
             RoleResource::class,
             PermissionResource::class

--- a/src/Resources/PermissionResource.php
+++ b/src/Resources/PermissionResource.php
@@ -57,6 +57,7 @@ class PermissionResource extends Resource
                             BelongsToManyMultiSelect::make('roles')
                                 ->label(__('filament-spatie-roles-permissions::filament-spatie.field.roles'))
                                 ->relationship('roles', 'name')
+                                ->preload(config('filament-spatie-roles-permissions.preload_roles'))
                         ])
                     ])
             ]);

--- a/src/Resources/RoleResource.php
+++ b/src/Resources/RoleResource.php
@@ -54,6 +54,7 @@ class RoleResource extends Resource
                                 BelongsToManyMultiSelect::make('permissions')
                                     ->label(__('filament-spatie-roles-permissions::filament-spatie.field.permissions'))
                                     ->relationship('permissions', 'name')
+                                    ->preload(config('filament-spatie-roles-permissions.preload_permissions'))
                             ])
                     ])
             ]);


### PR DESCRIPTION
This PR will make the Roles and Permissions fields are preloaded-able from the config file.

Also, fix a typo: `roles` -> `Roles`