### PR TITLE
Roles & Permissions automate Guard fill

### DIFF
--- a/src/Resources/PermissionResource.php
+++ b/src/Resources/PermissionResource.php
@@ -54,7 +54,12 @@ class PermissionResource extends Resource
                             TextInput::make('name')
                                 ->label(__('filament-spatie-roles-permissions::filament-spatie.field.name')),
                             TextInput::make('guard_name')
-                                ->label(__('filament-spatie-roles-permissions::filament-spatie.field.guard_name')),
+                                ->label(__('filament-spatie-roles-permissions::filament-spatie.field.guard_name'))
+                                ->datalist(config('filament-spatie-roles-permissions.generator.guard_names'))
+                                ->default(
+                                    count(config('filament-spatie-roles-permissions.generator.guard_names')) === 1 ?
+                                    config('filament-spatie-roles-permissions.generator.guard_names') : ''
+                                ),
                             Select::make('roles')
                                 ->multiple()
                                 ->label(__('filament-spatie-roles-permissions::filament-spatie.field.roles'))

--- a/src/Resources/RoleResource.php
+++ b/src/Resources/RoleResource.php
@@ -53,7 +53,12 @@ class RoleResource extends Resource
                                 TextInput::make('name')
                                     ->label(__('filament-spatie-roles-permissions::filament-spatie.field.name')),
                                 TextInput::make('guard_name')
-                                    ->label(__('filament-spatie-roles-permissions::filament-spatie.field.guard_name')),
+                                    ->label(__('filament-spatie-roles-permissions::filament-spatie.field.guard_name'))
+                                    ->datalist(config('filament-spatie-roles-permissions.generator.guard_names'))
+                                    ->default(
+                                        count(config('filament-spatie-roles-permissions.generator.guard_names')) === 1 ?
+                                            config('filament-spatie-roles-permissions.generator.guard_names') : ''
+                                    ),
                                 Select::make('permissions')
                                     ->multiple()
                                     ->label(__('filament-spatie-roles-permissions::filament-spatie.field.permissions'))


### PR DESCRIPTION
On creating/editing, prefil the guard if only 1 guard is set in the generator and start a datalist of the guards