### PR TITLE
fix: permission command tries to instantiate abstract classes

### DIFF
--- a/src/Commands/Permission.php
+++ b/src/Commands/Permission.php
@@ -188,7 +188,7 @@ class Permission extends Command
 
         foreach ($files as $file) {
             $namespace = $this->extractNamespace($file);
-            $class = new ($namespace . '\\' . $file->getFilenameWithoutExtension());
+            $class = $namespace . '\\' . $file->getFilenameWithoutExtension();
             $model = new ReflectionClass($class);
             if (!$model->isAbstract()) {
                 $models[] = $model;


### PR DESCRIPTION
**Fixes https://github.com/Althinect/filament-spatie-roles-permissions/issues/53**

The pushed fix in https://github.com/Althinect/filament-spatie-roles-permissions/commit/84ff3541893ae4a7f5efc39a4cca1dafd4ed972b doesn't fully do it because the code still attempts to instantiate abstract classes in `getClassesInDirectory`. Since reflection accepts the class name without requiring instantiation, I'm assuming the changes proposed in this PR won't introduce any behavior changes.

Thanks! 