### PR TITLE
Update FilamentSpatieRolesPermissionsServiceProvider.php

### DIFF
--- a/src/FilamentSpatieRolesPermissionsServiceProvider.php
+++ b/src/FilamentSpatieRolesPermissionsServiceProvider.php
@@ -5,11 +5,11 @@ namespace Althinect\FilamentSpatieRolesPermissions;
 use Althinect\FilamentSpatieRolesPermissions\Commands\Permission;
 use Althinect\FilamentSpatieRolesPermissions\Resources\PermissionResource;
 use Althinect\FilamentSpatieRolesPermissions\Resources\RoleResource;
-use Filament\PluginServiceProvider;
 use Illuminate\Support\ServiceProvider;
 use Spatie\LaravelPackageTools\Package;
+use Spatie\LaravelPackageTools\PackageServiceProvider;
 
-class FilamentSpatieRolesPermissionsServiceProvider extends PluginServiceProvider
+class FilamentSpatieRolesPermissionsServiceProvider extends PackageServiceProvider
 {
     public static string $name = 'filament-spatie-roles-permissions';
 


### PR DESCRIPTION
Fix error "Class "Filament\PluginServiceProvider" not found" when upgrading to Filament v3