### PR TITLE
Replacing "Filament\PluginServiceProvider" in ServiceProvider

### DIFF
--- a/src/FilamentSpatieRolesPermissionsServiceProvider.php
+++ b/src/FilamentSpatieRolesPermissionsServiceProvider.php
@@ -5,11 +5,10 @@ namespace Althinect\FilamentSpatieRolesPermissions;
 use Althinect\FilamentSpatieRolesPermissions\Commands\Permission;
 use Althinect\FilamentSpatieRolesPermissions\Resources\PermissionResource;
 use Althinect\FilamentSpatieRolesPermissions\Resources\RoleResource;
-use Filament\PluginServiceProvider;
-use Illuminate\Support\ServiceProvider;
+use Spatie\LaravelPackageTools\PackageServiceProvider;
 use Spatie\LaravelPackageTools\Package;
 
-class FilamentSpatieRolesPermissionsServiceProvider extends PluginServiceProvider
+class FilamentSpatieRolesPermissionsServiceProvider extends PackageServiceProvider
 {
     public static string $name = 'filament-spatie-roles-permissions';
 


### PR DESCRIPTION
Replacing "Filament\PluginServiceProvider"

When updating to Filament V3 I got an error.
`Class "Filament\PluginServiceProvider" not found`

See the link of the docs:
https://filamentphp.com/docs/3.x/support/plugins/getting-started#upgrading-existing-plugins