### PR TITLE
Add cache clear after updated and detached: 1.x

### DIFF
--- a/src/Resources/RoleResource/Pages/EditRole.php
+++ b/src/Resources/RoleResource/Pages/EditRole.php
@@ -4,9 +4,18 @@ namespace Althinect\FilamentSpatieRolesPermissions\Resources\RoleResource\Pages;
 
 use Althinect\FilamentSpatieRolesPermissions\Resources\RoleResource;
 use Filament\Resources\Pages\EditRecord;
+use Illuminate\Contracts\Container\BindingResolutionException;
+use Spatie\Permission\PermissionRegistrar;
 
 class EditRole extends EditRecord
 {
     protected static string $resource = RoleResource::class;
 
+    /**
+     * @throws BindingResolutionException
+     */
+    public function beforeSave()
+    {
+        app()->make(PermissionRegistrar::class)->forgetCachedPermissions();
+    }
 }

--- a/src/Resources/RoleResource/RelationManager/PermissionRelationManager.php
+++ b/src/Resources/RoleResource/RelationManager/PermissionRelationManager.php
@@ -9,6 +9,7 @@ use Filament\Resources\RelationManagers\BelongsToManyRelationManager;
 use Filament\Resources\Table;
 use Filament\Tables;
 use Filament\Tables\Columns\TextColumn;
+use Spatie\Permission\PermissionRegistrar;
 
 class PermissionRelationManager extends BelongsToManyRelationManager
 {
@@ -38,6 +39,9 @@ class PermissionRelationManager extends BelongsToManyRelationManager
             ]);
     }
 
+    /**
+     * @throws \Exception
+     */
     public static function table(Table $table): Table
     {
         return $table
@@ -49,6 +53,11 @@ class PermissionRelationManager extends BelongsToManyRelationManager
                     ->searchable()
                     ->label(__('filament-spatie-roles-permissions::filament-spatie.field.guard_name')),
 
+            ])
+            ->actions([
+                Tables\Actions\DeleteAction::make(),
+                Tables\Actions\EditAction::make(),
+                Tables\Actions\DetachAction::make()->after(fn() => app()->make(PermissionRegistrar::class)->forgetCachedPermissions()),
             ])
             ->filters([
                 //

--- a/src/Resources/RoleResource/RelationManager/PermissionRelationManager.php
+++ b/src/Resources/RoleResource/RelationManager/PermissionRelationManager.php
@@ -2,7 +2,6 @@
 
 namespace Althinect\FilamentSpatieRolesPermissions\Resources\RoleResource\RelationManager;
 
-use Filament\Forms;
 use Filament\Forms\Components\TextInput;
 use Filament\Resources\Form;
 use Filament\Resources\RelationManagers\BelongsToManyRelationManager;


### PR DESCRIPTION
The cache was not cleared when attaching the permissions of the role. That's why I've performed a cache wipe in the form where there are permission select fields and where there are detach events.
