### PR TITLE
Add Cache Clear After Permission Deleted And Attached with Bulk Actions

### DIFF
--- a/src/Resources/RoleResource/RelationManager/PermissionRelationManager.php
+++ b/src/Resources/RoleResource/RelationManager/PermissionRelationManager.php
@@ -71,4 +71,20 @@ class PermissionRelationManager extends BelongsToManyRelationManager
     {
         app()->make(PermissionRegistrar::class)->forgetCachedPermissions();
     }
+
+    /**
+     * @throws BindingResolutionException
+     */
+    public function afterBulkDelete()
+    {
+        app()->make(PermissionRegistrar::class)->forgetCachedPermissions();
+    }
+
+    /**
+     * @throws BindingResolutionException
+     */
+    public function afterBulkDetach()
+    {
+        app()->make(PermissionRegistrar::class)->forgetCachedPermissions();
+    }
 }

--- a/src/Resources/RoleResource/RelationManager/PermissionRelationManager.php
+++ b/src/Resources/RoleResource/RelationManager/PermissionRelationManager.php
@@ -8,6 +8,7 @@ use Filament\Resources\RelationManagers\BelongsToManyRelationManager;
 use Filament\Resources\Table;
 use Filament\Tables;
 use Filament\Tables\Columns\TextColumn;
+use Illuminate\Contracts\Container\BindingResolutionException;
 use Spatie\Permission\PermissionRegistrar;
 
 class PermissionRelationManager extends BelongsToManyRelationManager
@@ -54,12 +55,20 @@ class PermissionRelationManager extends BelongsToManyRelationManager
 
             ])
             ->actions([
-                Tables\Actions\DeleteAction::make(),
+                Tables\Actions\DeleteAction::make()->after(fn() => app()->make(PermissionRegistrar::class)->forgetCachedPermissions()),
                 Tables\Actions\EditAction::make(),
                 Tables\Actions\DetachAction::make()->after(fn() => app()->make(PermissionRegistrar::class)->forgetCachedPermissions()),
             ])
             ->filters([
                 //
             ]);
+    }
+
+    /**
+     * @throws BindingResolutionException
+     */
+    public function afterAttach()
+    {
+        app()->make(PermissionRegistrar::class)->forgetCachedPermissions();
     }
 }


### PR DESCRIPTION
After permissions are revoked or added, a cache clearing process has been implemented.