### PR TITLE
Enhancement: Tab title and table heading title in RelationManager can be translated correctly now.

### DIFF
--- a/resources/lang/zh_CN/filament-spatie.php
+++ b/resources/lang/zh_CN/filament-spatie.php
@@ -1,0 +1,32 @@
+<?php
+
+return [
+    /*
+    |--------------------------------------------------------------------------
+    | Fields
+    |--------------------------------------------------------------------------
+    */
+
+    'field.guard_name' => '认证看守器',
+    'field.permissions_count' => '权限数量',
+    'field.name' => '名称',
+    'field.permissions' => '权限',
+    'field.roles' => '角色',
+    'field.role' => '角色',
+    'field.team' => '团队',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Labels
+    |--------------------------------------------------------------------------
+    */
+
+    'section.permission' => '权限',
+    'section.permissions' => '权限',
+    'section.role' => '角色',
+    'section.roles' => '角色',
+    'section.roles_and_permissions' => '角色和权限',
+    'select-team' => '选择团队',
+    'select-team-hint' => '留空则使用全局角色',
+    'section.users' => '用户',
+];

--- a/src/Resources/PermissionResource/RelationManager/RoleRelationManager.php
+++ b/src/Resources/PermissionResource/RelationManager/RoleRelationManager.php
@@ -39,6 +39,8 @@ class RoleRelationManager extends RelationManager
     public function table(Table $table): Table
     {
         return $table
+            // Support changing table heading by translations.
+            ->heading(__('filament-spatie-roles-permissions::filament-spatie.section.roles'))
             ->columns([
                 TextColumn::make('name')
                     ->searchable()

--- a/src/Resources/RoleResource/RelationManager/PermissionRelationManager.php
+++ b/src/Resources/RoleResource/RelationManager/PermissionRelationManager.php
@@ -10,6 +10,7 @@ use Filament\Tables\Actions\DetachAction;
 use Filament\Tables\Actions\DetachBulkAction;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Model;
 use Spatie\Permission\PermissionRegistrar;
 
 class PermissionRelationManager extends RelationManager
@@ -17,6 +18,17 @@ class PermissionRelationManager extends RelationManager
     protected static string $relationship = 'permissions';
 
     protected static ?string $recordTitleAttribute = 'name';
+
+    /*
+     * Support changing tab title by translations in RelationManager.
+     */
+    public static function getTitle(Model $ownerRecord, string $pageClass): string
+    {
+        return __('filament-spatie-roles-permissions::filament-spatie.section.permissions') ?? (string)str(static::getRelationshipName())
+            ->kebab()
+            ->replace('-', ' ')
+            ->headline();
+    }
 
     protected static function getModelLabel(): string
     {
@@ -42,6 +54,8 @@ class PermissionRelationManager extends RelationManager
     public function table(Table $table): Table
     {
         return $table
+            // Support changing table heading by translations.
+            ->heading(__('filament-spatie-roles-permissions::filament-spatie.section.permissions'))
             ->columns([
                 TextColumn::make('name')
                     ->searchable()

--- a/src/Resources/RoleResource/RelationManager/UserRelationManager.php
+++ b/src/Resources/RoleResource/RelationManager/UserRelationManager.php
@@ -9,6 +9,7 @@ use Filament\Tables\Actions\AttachAction;
 use Filament\Tables\Actions\DetachAction;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Model;
 
 class UserRelationManager extends RelationManager
 {
@@ -16,6 +17,16 @@ class UserRelationManager extends RelationManager
 
     protected static ?string $recordTitleAttribute = 'name';
 
+    /*
+     * Support changing tab title in RelationManager.
+     */
+    public static function getTitle(Model $ownerRecord, string $pageClass): string
+    {
+        return __('filament-spatie-roles-permissions::filament-spatie.section.users') ?? (string)str(static::getRelationshipName())
+            ->kebab()
+            ->replace('-', ' ')
+            ->headline();
+    }
 
     protected static function getModelLabel(): string
     {
@@ -39,6 +50,8 @@ class UserRelationManager extends RelationManager
     public function table(Table $table): Table
     {
         return $table
+            // Support changing table heading by translations.
+            ->heading(__('filament-spatie-roles-permissions::filament-spatie.section.users'))
             ->columns([
                 TextColumn::make('name')
                     ->searchable()


### PR DESCRIPTION
Here are two features.
1, The tab title and table heading title cannot be translated before, but now it works.
```php
// I cannot do this below.
protected static ?string $title = __('key');

// So I overwrite this function to change the title by translations.
public static function getTitle(Model $ownerRecord, string $pageClass): string
{
    return __('filament-spatie-roles-permissions::filament-spatie.section.users') ?? (string)str(static::getRelationshipName())
        ->kebab()
        ->replace('-', ' ')
        ->headline();
}
```
2, Add some translation files for `zh_CN`.

Above all, PLZ check ^ ^