### PR TITLE
Allow for customization to the navigation icon for roles/permissions

### DIFF
--- a/config/filament-spatie-roles-permissions.php
+++ b/config/filament-spatie-roles-permissions.php
@@ -18,6 +18,11 @@ return [
         'roles' => true
     ],
 
+    'navigation_icon' => [
+        'permissions' => 'heroicon-o-lock-closed',
+        'roles' => 'heroicon-o-user-group',
+    ],
+
     'guard_names' => [
         'web' => 'web',
         'api' => 'api'

--- a/src/Resources/PermissionResource.php
+++ b/src/Resources/PermissionResource.php
@@ -22,7 +22,11 @@ use Spatie\Permission\Models\Permission;
 
 class PermissionResource extends Resource
 {
-    protected static ?string $navigationIcon = 'heroicon-o-lock-closed';
+
+    public static function getNavigationIcon(): string
+    {
+        return $navigationIcon = config('filament-spatie-roles-permissions.navigation_icon.permissions', 'heroicon-o-lock-closed');
+    }
 
     public static function shouldRegisterNavigation(): bool
     {

--- a/src/Resources/RoleResource.php
+++ b/src/Resources/RoleResource.php
@@ -21,7 +21,10 @@ use Spatie\Permission\Models\Role;
 
 class RoleResource extends Resource
 {
-    protected static ?string $navigationIcon = 'heroicon-o-user-group';
+    public static function getNavigationIcon(): string
+    {
+        return $navigationIcon = config('filament-spatie-roles-permissions.navigation_icon.roles', 'heroicon-o-user-group');
+    }
 
     public static function shouldRegisterNavigation(): bool
     {


### PR DESCRIPTION
These changes would allow the developer to customize the navigation icon for Permissions and Roles within Filament Admin:

<img width="312" alt="image" src="https://github.com/Althinect/filament-spatie-roles-permissions/assets/62491401/56eafa74-23ef-4b8e-835d-7993f17e9fac">
