### PR TITLE
Add tenant sync middleware

### DIFF
--- a/src/FilamentSpatieRolesPermissionsPlugin.php
+++ b/src/FilamentSpatieRolesPermissionsPlugin.php
@@ -20,8 +20,10 @@ class FilamentSpatieRolesPermissionsPlugin implements Plugin
             ->resources([
                 RoleResource::class,
                 PermissionResource::class,
-            ]);
-
+            ])
+            ->tenantMiddleware([
+                SyncSpatiePermissionsTenantsWithFilament::class,
+            ], isPersistent: true);
     }
 
     public static function make(): static

--- a/src/Middleware/SyncSpatiePermissionsTenantsWithFilament.php
+++ b/src/Middleware/SyncSpatiePermissionsTenantsWithFilament.php
@@ -7,7 +7,7 @@ use Filament\Facades\Filament;
 use Illuminate\Http\Request;
 use Symfony\Component\HttpFoundation\Response;
 
-class SyncSpatiePermissionsWithFilament
+class SyncSpatiePermissionsTenantsWithFilament
 {
     /**
      * Handle an incoming request.

--- a/src/Middleware/SyncSpatiePermissionsWithFilament.php
+++ b/src/Middleware/SyncSpatiePermissionsWithFilament.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Filament\Facades\Filament;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class SyncSpatiePermissionsWithFilament
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param Closure(Request): (Response) $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        $filament = Filament::getTenant()->id;
+        $spatie = getPermissionsTeamId();
+        if ($filament !== $spatie) {
+            setPermissionsTeamId($filament);
+        }
+
+        return $next($request);
+    }
+}


### PR DESCRIPTION
I am assuming ->tenantMiddleware() will have no effect if ->tenant() isn't called. If it does though, I guess it needs to only be added if tenancy is active.