### PR TITLE
Fix typo in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Permission and Policy generations
 - Check the ``config/filament-spatie-roles-permissions-config.php``
 
 Supports permissions for teams
-- Make sure the ``teams`` attribute in the ``app/permission.php`` file is set to ``true``
+- Make sure the ``teams`` attribute in the ``config/permission.php`` file is set to ``true``
 
 ## Updating
 


### PR DESCRIPTION
I'm pretty sure you meant this to refer to the config file from the Spatie plugin, which is located in the `config` directory.