### PR TITLE
Enhance namespace resolver

### DIFF
--- a/src/Commands/Permission.php
+++ b/src/Commands/Permission.php
@@ -239,6 +239,7 @@ class Permission extends Command
         $handle = fopen($file, 'r');
         if ($handle) {
             while (($line = fgets($handle)) !== false) {
+                $line = trim($line);
                 if (str_starts_with($line, 'namespace')) {
                     $parts = explode(' ', $line);
                     $ns = rtrim(trim($parts[1]), ';');

--- a/src/Commands/Permission.php
+++ b/src/Commands/Permission.php
@@ -239,7 +239,7 @@ class Permission extends Command
         $handle = fopen($file, 'r');
         if ($handle) {
             while (($line = fgets($handle)) !== false) {
-                $line = trim($line);
+                $line = str($line)->remove('<?php')->remove('<?')->trim();
                 if (str_starts_with($line, 'namespace')) {
                     $parts = explode(' ', $line);
                     $ns = rtrim(trim($parts[1]), ';');


### PR DESCRIPTION
The current `getNamespace` function is reading line by line and checks if it starts with `namespace`. It means that your model has always to be like

```
<?php
namespace App\Models; 

class Post extends Model {

}
```

Different types of code styling would break the file and could result in exceptions.

```
<?php namespace App\Models; 

class Post extends Model {

}
```

```
<?php
    namespace App\Models; 

class Post extends Model {

}
```

The two upper classes would result in `Class \Post not found`