### PR TITLE
Append guard name

### DIFF
--- a/src/Resources/RoleResource.php
+++ b/src/Resources/RoleResource.php
@@ -85,7 +85,6 @@ class RoleResource extends Resource
                                     ->searchable(['name', 'guard_name']) // searchable on both name and guard_name
                                     ->preload(config('filament-spatie-roles-permissions.preload_permissions')),
 
-
                                 Select::make(config('permission.column_names.team_foreign_key', 'team_id'))
                                     ->label(__('filament-spatie-roles-permissions::filament-spatie.field.team'))
                                     ->hidden(fn () => ! config('permission.teams', false) || Filament::hasTenancy())

--- a/src/Resources/RoleResource.php
+++ b/src/Resources/RoleResource.php
@@ -18,6 +18,7 @@ use Filament\Resources\Resource;
 use Filament\Tables;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
+use Spatie\Permission\Models\Role;
 
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
@@ -85,7 +86,7 @@ class RoleResource extends Resource
                                     ->searchable(['name', 'guard_name'])
                                     ->preload(config('filament-spatie-roles-permissions.preload_permissions')),
 
-                                    
+
                                 Select::make(config('permission.column_names.team_foreign_key', 'team_id'))
                                     ->label(__('filament-spatie-roles-permissions::filament-spatie.field.team'))
                                     ->hidden(fn () => ! config('permission.teams', false) || Filament::hasTenancy())

--- a/src/Resources/RoleResource.php
+++ b/src/Resources/RoleResource.php
@@ -18,7 +18,9 @@ use Filament\Resources\Resource;
 use Filament\Tables;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
-use Spatie\Permission\Models\Role;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
 
 class RoleResource extends Resource
 {
@@ -64,17 +66,26 @@ class RoleResource extends Resource
                                 TextInput::make('name')
                                     ->label(__('filament-spatie-roles-permissions::filament-spatie.field.name'))
                                     ->required(),
+
                                 Select::make('guard_name')
                                     ->label(__('filament-spatie-roles-permissions::filament-spatie.field.guard_name'))
                                     ->options(config('filament-spatie-roles-permissions.guard_names'))
                                     ->default(config('filament-spatie-roles-permissions.default_guard_name'))
                                     ->required(),
+
                                 Select::make('permissions')
                                     ->columnSpanFull()
                                     ->multiple()
                                     ->label(__('filament-spatie-roles-permissions::filament-spatie.field.permissions'))
-                                    ->relationship('permissions', 'name')
+                                    ->relationship(
+                                        name: 'permissions',
+                                        modifyQueryUsing: fn (Builder $query) => $query->orderBy('name')->orderBy('name'),
+                                    )
+                                    ->getOptionLabelFromRecordUsing(fn (Model $record) => "{$record->name} ({$record->guard_name})")
+                                    ->searchable(['name', 'guard_name'])
                                     ->preload(config('filament-spatie-roles-permissions.preload_permissions')),
+
+                                    
                                 Select::make(config('permission.column_names.team_foreign_key', 'team_id'))
                                     ->label(__('filament-spatie-roles-permissions::filament-spatie.field.team'))
                                     ->hidden(fn () => ! config('permission.teams', false) || Filament::hasTenancy())

--- a/src/Resources/RoleResource.php
+++ b/src/Resources/RoleResource.php
@@ -19,7 +19,6 @@ use Filament\Tables;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
 use Spatie\Permission\Models\Role;
-
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 
@@ -83,7 +82,7 @@ class RoleResource extends Resource
                                         modifyQueryUsing: fn (Builder $query) => $query->orderBy('name')->orderBy('name'),
                                     )
                                     ->getOptionLabelFromRecordUsing(fn (Model $record) => "{$record->name} ({$record->guard_name})")
-                                    ->searchable(['name', 'guard_name'])
+                                    ->searchable(['name', 'guard_name']) // searchable on both name and guard_name
                                     ->preload(config('filament-spatie-roles-permissions.preload_permissions')),
 
 


### PR DESCRIPTION
Append guard to permission dropdown when creating/editing roles. That way it's easier to know which specific permission you're adding to the role. Guard name is included in brackets to differentiate web and API guards. See below:

![image](https://github.com/Althinect/filament-spatie-roles-permissions/assets/28390917/f19dce7e-bd7f-492a-93b1-fdbc4de226f6)


