### PR TITLE
Regular Expression changed into Permission.php in Commands folder

### DIFF
--- a/src/Commands/Permission.php
+++ b/src/Commands/Permission.php
@@ -243,6 +243,10 @@ class Permission extends Command
                 if (str_starts_with($line, 'namespace')) {
                     $parts = explode(' ', $line);
                     $ns = rtrim(trim($parts[1]), ';');
+                    // it removes 6 characters from $ns variable
+                    if (str_ends_with($ns, 'use')){
+                        $ns = substr($ns, 0, strlen($ns) - 6);
+                    }
                     break;
                 }
             }


### PR DESCRIPTION
## Check this.
`preg_match('/namespace\s+([a-zA-Z0-9_\\\\]+);/', $line, $matches)`


![image](https://github.com/Althinect/filament-spatie-roles-permissions/assets/43345536/4472abf6-2d67-41e8-8926-4b9a33c32dd4)
