### PR TITLE
Change how guard_name interects with the Permission form

### DIFF
--- a/src/Resources/PermissionResource.php
+++ b/src/Resources/PermissionResource.php
@@ -14,6 +14,8 @@ use Filament\Forms\Components\Section;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Form;
+use Filament\Forms\Get;
+use Filament\Forms\Set;
 use Filament\Resources\Resource;
 use Filament\Tables;
 use Filament\Tables\Actions\BulkAction;
@@ -78,6 +80,8 @@ class PermissionResource extends Resource
                                 ->label(__('filament-spatie-roles-permissions::filament-spatie.field.guard_name'))
                                 ->options(config('filament-spatie-roles-permissions.guard_names'))
                                 ->default(config('filament-spatie-roles-permissions.default_guard_name'))
+                                ->live()
+                                ->afterStateUpdated(fn (Set $set) => $set('roles', null))
                                 ->required(),
                             Select::make('roles')
                                 ->multiple()
@@ -85,7 +89,10 @@ class PermissionResource extends Resource
                                 ->relationship(
                                     name: 'roles',
                                     titleAttribute: 'name',
-                                    modifyQueryUsing: function(Builder $query) {
+                                    modifyQueryUsing: function(Builder $query, Get $get) {
+                                        if (!empty($get('guard_name'))) {
+                                            $query->where('guard_name', $get('guard_name'));
+                                        }
                                         if(Filament::hasTenancy()) {
                                             return $query->where(config('permission.column_names.team_foreign_key'), Filament::getTenant());
                                         }


### PR DESCRIPTION
# Description

Changed how the guard_name select input interacts with the form. Now when a guard_name is this will reset the selected values on roles and it will also filter to bring only the roles related to the selected guard.

## Motivation

Because normally here we work with multiples guards with roles with same name was hard to pinpoint which role as linked to the correct guard.