### PR TITLE
Fix unique name for roles, scope to tenant disabling

### DIFF
--- a/config/filament-spatie-roles-permissions.php
+++ b/config/filament-spatie-roles-permissions.php
@@ -9,6 +9,8 @@ return [
     'navigation_section_group' => 'filament-spatie-roles-permissions::filament-spatie.section.roles_and_permissions', // Default uses language constant
 
     'team_model' => \App\Models\Team::class,
+    
+    'scope_to_tenant' => true,
 
     /*
      * Set as false to remove from navigation.

--- a/src/Resources/RoleResource.php
+++ b/src/Resources/RoleResource.php
@@ -25,7 +25,13 @@ use Illuminate\Database\Eloquent\Model;
 
 class RoleResource extends Resource
 {
-
+    
+    
+    public static function isScopedToTenant(): bool
+    {
+        return config('filament-spatie-roles-permissions.scope_to_tenant', true);
+    }
+    
     public static function getNavigationIcon(): ?string
     {
         return  config('filament-spatie-roles-permissions.icons.role_navigation');


### PR DESCRIPTION
1. Fixes the unique validation for role creation with tenant support
2. Allows disabling scoping to tenant, as by default Filament scopes resources but the issue with spatie and doing this is we try and scope a role to the tenant when we have already done that on the roles resource. To avoid BC changes we leave it on by default incase some users have a working implementation. 