### PR TITLE
Add Cluster support

### DIFF
--- a/config/filament-spatie-roles-permissions.php
+++ b/config/filament-spatie-roles-permissions.php
@@ -25,6 +25,15 @@ return [
         'roles' => true,
     ],
 
+    /*
+     * If you want to place the Resource in a Cluster, then set the required Cluster class.
+     * Eg. \App\Filament\Clusters\Cluster::class
+     */
+    'clusters' => [
+        'permissions' => null,
+        'roles' => null,
+    ],
+
     'guard_names' => [
         'web' => 'web',
         'api' => 'api',

--- a/src/Resources/PermissionResource.php
+++ b/src/Resources/PermissionResource.php
@@ -65,6 +65,11 @@ class PermissionResource extends Resource
         return __('filament-spatie-roles-permissions::filament-spatie.section.permissions');
     }
 
+    public static function getCluster(): ?string
+    {
+        return config('filament-spatie-roles-permissions.clusters.permissions', null);
+    }
+    
     public static function form(Form $form): Form
     {
         return $form

--- a/src/Resources/RoleResource.php
+++ b/src/Resources/RoleResource.php
@@ -67,6 +67,11 @@ class RoleResource extends Resource
         return __('filament-spatie-roles-permissions::filament-spatie.section.roles');
     }
 
+    public static function getCluster(): ?string
+    {
+        return config('filament-spatie-roles-permissions.clusters.roles', null);
+    }
+
     public static function form(Form $form): Form
     {
         return $form


### PR DESCRIPTION
I tried adding the resources to [Clusters](https://filamentphp.com/docs/3.x/panels/clusters), but when extending the Resource and using the new system from #172, it breaks on generating the cluster page URLs and then will also not show the Cluster menu when on the resource.

I believe the Cluster config needs to be on the base Resource class.

I've therefore added the ability to set the Cluster Class to use for each resource in the config file.