### PR TITLE
recordTitle fixed for user_name_column

### DIFF
--- a/src/Resources/RoleResource/RelationManager/UserRelationManager.php
+++ b/src/Resources/RoleResource/RelationManager/UserRelationManager.php
@@ -15,7 +15,10 @@ class UserRelationManager extends RelationManager
 {
     protected static string $relationship = 'users';
 
-    protected static ?string $recordTitleAttribute = 'name';
+    public static function getRecordTitleAttribute(): ?string
+    {
+        return config('filament-spatie-roles-permissions.user_name_column');
+    }
 
     /*
      * Support changing tab title in RelationManager.


### PR DESCRIPTION
In the UserRelationManager class, it was previously not aware of the config file. With these changes, it now is.

We are simply retrieving the recordTitleAttribute from a static method that returns the config value.