### PR TITLE
Add config option to redirect to the resource index instead of the view

### DIFF
--- a/config/filament-spatie-roles-permissions.php
+++ b/config/filament-spatie-roles-permissions.php
@@ -25,6 +25,20 @@ return [
         'roles' => true,
     ],
 
+    /**
+     * Set to true to redirect to the resource index instead of the view
+     */
+    'should_redirect_to_index' => [
+        'permissions' => [
+            'after_create' => false,
+            'after_edit' => false
+        ],
+        'roles' => [
+            'after_create' => false,
+            'after_edit' => false
+        ],
+    ],
+
     /*
      * If you want to place the Resource in a Cluster, then set the required Cluster class.
      * Eg. \App\Filament\Clusters\Cluster::class

--- a/src/Resources/PermissionResource/Pages/CreatePermission.php
+++ b/src/Resources/PermissionResource/Pages/CreatePermission.php
@@ -3,9 +3,17 @@
 namespace Althinect\FilamentSpatieRolesPermissions\Resources\PermissionResource\Pages;
 
 use Althinect\FilamentSpatieRolesPermissions\Resources\PermissionResource;
+use Althinect\FilamentSpatieRolesPermissions\Resources\RoleResource;
 use Filament\Resources\Pages\CreateRecord;
 
 class CreatePermission extends CreateRecord
 {
     protected static string $resource = PermissionResource::class;
+
+    protected function getRedirectUrl(): string
+    {
+        return config('filament-spatie-roles-permissions.should_redirect_to_index.permissions.after_create')
+            ? PermissionResource::getUrl('index')
+            : PermissionResource::getUrl('view');
+    }
 }

--- a/src/Resources/PermissionResource/Pages/CreatePermission.php
+++ b/src/Resources/PermissionResource/Pages/CreatePermission.php
@@ -12,8 +12,10 @@ class CreatePermission extends CreateRecord
 
     protected function getRedirectUrl(): string
     {
-        return config('filament-spatie-roles-permissions.should_redirect_to_index.permissions.after_create')
-            ? PermissionResource::getUrl('index')
-            : PermissionResource::getUrl('view');
+        $resource = static::getResource();
+
+        return config('filament-spatie-roles-permissions.should_redirect_to_index.permissions.after_create', false)
+            ? $resource::getUrl('index')
+            : parent::getRedirectUrl();
     }
 }

--- a/src/Resources/PermissionResource/Pages/EditPermission.php
+++ b/src/Resources/PermissionResource/Pages/EditPermission.php
@@ -8,4 +8,11 @@ use Filament\Resources\Pages\EditRecord;
 class EditPermission extends EditRecord
 {
     protected static string $resource = PermissionResource::class;
+
+    protected function getRedirectUrl(): string
+    {
+        return config('filament-spatie-roles-permissions.should_redirect_to_index.permissions.after_edit')
+            ? PermissionResource::getUrl('index')
+            : PermissionResource::getUrl('view');
+    }
 }

--- a/src/Resources/PermissionResource/Pages/EditPermission.php
+++ b/src/Resources/PermissionResource/Pages/EditPermission.php
@@ -9,10 +9,12 @@ class EditPermission extends EditRecord
 {
     protected static string $resource = PermissionResource::class;
 
-    protected function getRedirectUrl(): string
+    protected function getRedirectUrl(): ?string
     {
-        return config('filament-spatie-roles-permissions.should_redirect_to_index.permissions.after_edit')
-            ? PermissionResource::getUrl('index')
-            : PermissionResource::getUrl('view');
+        $resource = static::getResource();
+
+        return config('filament-spatie-roles-permissions.should_redirect_to_index.permissions.after_edit', false)
+            ? $resource::getUrl('index')
+            : parent::getRedirectUrl();
     }
 }

--- a/src/Resources/RoleResource/Pages/CreateRole.php
+++ b/src/Resources/RoleResource/Pages/CreateRole.php
@@ -8,4 +8,11 @@ use Filament\Resources\Pages\CreateRecord;
 class CreateRole extends CreateRecord
 {
     protected static string $resource = RoleResource::class;
+
+    protected function getRedirectUrl(): string
+    {
+        return config('filament-spatie-roles-permissions.should_redirect_to_index.roles.after_create')
+            ? RoleResource::getUrl('index')
+            : RoleResource::getUrl('view');
+    }
 }

--- a/src/Resources/RoleResource/Pages/CreateRole.php
+++ b/src/Resources/RoleResource/Pages/CreateRole.php
@@ -11,8 +11,10 @@ class CreateRole extends CreateRecord
 
     protected function getRedirectUrl(): string
     {
-        return config('filament-spatie-roles-permissions.should_redirect_to_index.roles.after_create')
-            ? RoleResource::getUrl('index')
-            : RoleResource::getUrl('view');
+        $resource = static::getResource();
+
+        return config('filament-spatie-roles-permissions.should_redirect_to_index.roles.after_create', false)
+            ? $resource::getUrl('index')
+            : parent::getRedirectUrl();
     }
 }

--- a/src/Resources/RoleResource/Pages/EditRole.php
+++ b/src/Resources/RoleResource/Pages/EditRole.php
@@ -19,10 +19,12 @@ class EditRole extends EditRecord
         ];
     }
 
-    protected function getRedirectUrl(): string
+    protected function getRedirectUrl(): ?string
     {
-        return config('filament-spatie-roles-permissions.should_redirect_to_index.roles.after_edit')
-            ? RoleResource::getUrl('index')
-            : RoleResource::getUrl('view');
+        $resource = static::getResource();
+
+        return config('filament-spatie-roles-permissions.should_redirect_to_index.roles.after_create', false)
+            ? $resource::getUrl('index')
+            : parent::getRedirectUrl();
     }
 }

--- a/src/Resources/RoleResource/Pages/EditRole.php
+++ b/src/Resources/RoleResource/Pages/EditRole.php
@@ -18,4 +18,11 @@ class EditRole extends EditRecord
             DeleteAction::make(),
         ];
     }
+
+    protected function getRedirectUrl(): string
+    {
+        return config('filament-spatie-roles-permissions.should_redirect_to_index.roles.after_edit')
+            ? RoleResource::getUrl('index')
+            : RoleResource::getUrl('view');
+    }
 }


### PR DESCRIPTION
Add config option `should_redirect_to_index` to redirect to the resource index instead of the view.

Example:
```
'should_redirect_to_index' => [
        'permissions' => [
            'after_create' => true,
            'after_edit'   => true,
        ],
        'roles' => [
            'after_create' => true,
            'after_edit'   => true,
        ],
    ],
```

Default is false to mantain the current behavior

