### PR TITLE
Update PermissionResource avoiding Error if Tenancy is deactivated in…

### DIFF
--- a/src/Resources/PermissionResource.php
+++ b/src/Resources/PermissionResource.php
@@ -98,7 +98,7 @@ class PermissionResource extends Resource
                                         if (!empty($get('guard_name'))) {
                                             $query->where('guard_name', $get('guard_name'));
                                         }
-                                        if(Filament::hasTenancy()) {
+                                        if(config('permission.teams', false) && Filament::hasTenancy()) {
                                             return $query->where(config('permission.column_names.team_foreign_key'), Filament::getTenant()->id);
                                         }
                                         return $query;


### PR DESCRIPTION
… plugin

If tenancy is activated in Filament, but you do not want to have specific rights roles and permissions per tenant, then an SQL error was caused here because the team_id was incorrectly added.