### PR TITLE
Resource Override Functionality

### DIFF
--- a/src/Resources/PermissionResource/Pages/CreatePermission.php
+++ b/src/Resources/PermissionResource/Pages/CreatePermission.php
@@ -8,7 +8,12 @@ use Filament\Resources\Pages\CreateRecord;
 
 class CreatePermission extends CreateRecord
 {
-    protected static string $resource = PermissionResource::class;
+    protected static string $resource;
+
+    public function __construct()
+    {
+        self::$resource = config('filament-spatie-roles-permissions.resources.PermissionResource', PermissionResource::class);
+    }
 
     protected function getRedirectUrl(): string
     {

--- a/src/Resources/PermissionResource/Pages/EditPermission.php
+++ b/src/Resources/PermissionResource/Pages/EditPermission.php
@@ -7,7 +7,12 @@ use Filament\Resources\Pages\EditRecord;
 
 class EditPermission extends EditRecord
 {
-    protected static string $resource = PermissionResource::class;
+    protected static string $resource;
+
+    public function __construct()
+    {
+        self::$resource = config('filament-spatie-roles-permissions.resources.PermissionResource', PermissionResource::class);
+    }
 
     protected function getRedirectUrl(): ?string
     {

--- a/src/Resources/PermissionResource/Pages/ListPermissions.php
+++ b/src/Resources/PermissionResource/Pages/ListPermissions.php
@@ -11,7 +11,12 @@ use Illuminate\Database\Eloquent\Collection;
 
 class ListPermissions extends ListRecords
 {
-    protected static string $resource = PermissionResource::class;
+    protected static string $resource;
+
+    public function __construct()
+    {
+        self::$resource = config('filament-spatie-roles-permissions.resources.PermissionResource', PermissionResource::class);
+    }
 
     protected function getHeaderActions(): array
     {
@@ -39,6 +44,5 @@ class ListPermissions extends ListRecords
                         ->required(),
                 ])->deselectRecordsAfterCompletion(),
         ];
-
     }
 }

--- a/src/Resources/PermissionResource/Pages/ViewPermission.php
+++ b/src/Resources/PermissionResource/Pages/ViewPermission.php
@@ -8,7 +8,12 @@ use Filament\Resources\Pages\ViewRecord;
 
 class ViewPermission extends ViewRecord
 {
-    protected static string $resource = PermissionResource::class;
+    protected static string $resource;
+
+    public function __construct()
+    {
+        self::$resource = config('filament-spatie-roles-permissions.resources.PermissionResource', PermissionResource::class);
+    }
 
     public function getHeaderActions(): array
     {

--- a/src/Resources/RoleResource/Pages/CreateRole.php
+++ b/src/Resources/RoleResource/Pages/CreateRole.php
@@ -7,7 +7,12 @@ use Filament\Resources\Pages\CreateRecord;
 
 class CreateRole extends CreateRecord
 {
-    protected static string $resource = RoleResource::class;
+    protected static string $resource;
+
+    public function __construct()
+    {
+        self::$resource = config('filament-spatie-roles-permissions.resources.RoleResource', RoleResource::class);
+    }
 
     protected function getRedirectUrl(): string
     {

--- a/src/Resources/RoleResource/Pages/EditRole.php
+++ b/src/Resources/RoleResource/Pages/EditRole.php
@@ -9,7 +9,12 @@ use Filament\Resources\Pages\EditRecord;
 
 class EditRole extends EditRecord
 {
-    protected static string $resource = RoleResource::class;
+    protected static string $resource;
+
+    public function __construct()
+    {
+        self::$resource = config('filament-spatie-roles-permissions.resources.RoleResource', RoleResource::class);
+    }
 
     public function getHeaderActions(): array
     {

--- a/src/Resources/RoleResource/Pages/ListRoles.php
+++ b/src/Resources/RoleResource/Pages/ListRoles.php
@@ -8,7 +8,12 @@ use Filament\Resources\Pages\ListRecords;
 
 class ListRoles extends ListRecords
 {
-    protected static string $resource = RoleResource::class;
+    protected static string $resource;
+
+    public function __construct()
+    {
+        self::$resource = config('filament-spatie-roles-permissions.resources.RoleResource', RoleResource::class);
+    }
 
     protected function getHeaderActions(): array
     {

--- a/src/Resources/RoleResource/Pages/ViewRole.php
+++ b/src/Resources/RoleResource/Pages/ViewRole.php
@@ -8,7 +8,12 @@ use Filament\Resources\Pages\ViewRecord;
 
 class ViewRole extends ViewRecord
 {
-    protected static string $resource = RoleResource::class;
+    protected static string $resource;
+
+    public function __construct()
+    {
+        self::$resource = config('filament-spatie-roles-permissions.resources.RoleResource', RoleResource::class);
+    }
 
     public function getHeaderActions(): array
     {


### PR DESCRIPTION
When defining a resource in the config to extend, the form and table functions would not detect any changes. 

Each page from the resource was hardcoded to take the resource class, I've changed to take the config class before defaulting back to the resource class from the package.