### PR TITLE
Fixes when using multiple searchable columns

### DIFF
--- a/src/Resources/RoleResource/RelationManager/UserRelationManager.php
+++ b/src/Resources/RoleResource/RelationManager/UserRelationManager.php
@@ -63,7 +63,11 @@ class UserRelationManager extends RelationManager
             ->filters([
 
             ])->headerActions([
-                AttachAction::make(),
+                AttachAction::make()
+                    ->recordSelectSearchColumns(config('filament-spatie-roles-permissions.user_name_searchable_columns', 'name'))
+                    ->recordTitle(function ($record) {
+                        return $record->getAttributeValue(config('filament-spatie-roles-permissions.user_name_column', 'name'));
+                    }),
             ])->actions([
                 DetachAction::make(),
             ])->bulkActions([

--- a/src/Resources/RoleResource/RelationManager/UserRelationManager.php
+++ b/src/Resources/RoleResource/RelationManager/UserRelationManager.php
@@ -58,7 +58,7 @@ class UserRelationManager extends RelationManager
             ->columns([
                 TextColumn::make(config('filament-spatie-roles-permissions.user_name_column'))
                     ->label(__('filament-spatie-roles-permissions::filament-spatie.field.name'))
-                    ->searchable(config('filament-spatie-roles-permissions.user_name_searchable_columns', 'name')),
+                    ->searchable(config('filament-spatie-roles-permissions.user_name_searchable_columns', 'name') ?? true),
             ])
             ->filters([
 


### PR DESCRIPTION
This PR fixes 2 problems when using multiple searchable columns.

1. [Fixed exception when user_name_searchable_columns is null](https://github.com/Althinect/filament-spatie-roles-permissions/commit/123a51acc87ba24102b006560ca1a30c037383c8)


null is not a valid type for this parameter, so default to true

------

2. [Fixed the AttachAction when using user_name_searchable_columns](https://github.com/Althinect/filament-spatie-roles-permissions/commit/ba3401161d8fea82433c2ed938e3620df162ed8f)

This fixes an exception when using user_name_searchable_columns by skipping the orderBy clause in the following code using recordTitle instead:
https://github.com/filamentphp/filament/blob/86db630d700d7cd727de6c51864b7ce43c38d15b/packages/tables/src/Actions/AttachAction.php#L261-L273

Maybe this should be fixed upstream in filament too, by skipping this section when `recordSelectSearchColumns` are set? 

Before:
```
 Column not found: 1054 Unknown column 'users.name' in 'where clause' (Connection: mysql, SQL: select distinct `users`.* from `users` left join `model_has_roles` on `users`.`id` = `model_has_roles`.`model_id` where (`users`.`name` like %Test%) and not exists (select * from `roles` inner join `model_has_roles` on `roles`.`id` = `model_has_roles`.`role_id` where `users`.`id` = `model_has_roles`.`model_id` and `model_has_roles`.`model_type` = App\Models\User and `roles`.`id` = 2) order by `users`.`name` asc limit 50)
```

After:
```
select distinct `users`.* from `users` left join `model_has_roles` on `users`.`id` = `model_has_roles`.`model_id` where (`users`.`firstname` like '%gab%' or `users`.`lastname` like '%Test%') and not exists (select * from `roles` inner join `model_has_roles` on `roles`.`id` = `model_has_roles`.`role_id` where `users`.`id` = `model_has_roles`.`model_id` and `model_has_roles`.`model_type` = 'App\\Models\\User' and `roles`.`id` = 2) limit 50
```