### PR TITLE
Allow customization of Super Admin role

### DIFF
--- a/config/filament-spatie-roles-permissions.php
+++ b/config/filament-spatie-roles-permissions.php
@@ -17,6 +17,8 @@ return [
 
     'scope_to_tenant' => true,
 
+    'super_admin_role_name' => 'Super Admin',
+
     /*
      * Set as false to remove from navigation.
      */

--- a/src/Concerns/HasSuperAdmin.php
+++ b/src/Concerns/HasSuperAdmin.php
@@ -10,6 +10,6 @@ trait HasSuperAdmin
 
     public function isSuperAdmin(): bool
     {
-        return $this->hasRole('Super Admin');
+        return $this->hasRole(config('filament-spatie-roles-permissions.super_admin_role_name', 'Super Admin'));
     }
 }


### PR DESCRIPTION
The super admin role might not always be `Super Admin`.

In my case I have an existing platform with data and the role is `super-admin`. 

This PR adds a config option to customize this, as well as a check in the `HasSuperAdmin` trait; but defaults to `Super Admin` if this option is not set.