### PR TITLE
Separate scope_to_tenant for Roles and Permissions

### DIFF
--- a/config/filament-spatie-roles-permissions.php
+++ b/config/filament-spatie-roles-permissions.php
@@ -15,10 +15,10 @@ return [
 
     'team_model' => \App\Models\Team::class,
 
-     'scope_to_tenant' => [
-        'roles' => true,
-        'permissions' => false,
-    ],
+    'scope_to_tenant' => true,
+    
+    'scope_roles_to_tenant' => true,
+    'scope_premissions_to_tenant' => false,
 
     'super_admin_role_name' => 'Super Admin',
 

--- a/config/filament-spatie-roles-permissions.php
+++ b/config/filament-spatie-roles-permissions.php
@@ -15,7 +15,10 @@ return [
 
     'team_model' => \App\Models\Team::class,
 
-    'scope_to_tenant' => true,
+     'scope_to_tenant' => [
+        'roles' => true,
+        'permissions' => false,
+    ],
 
     'super_admin_role_name' => 'Super Admin',
 

--- a/src/Resources/PermissionResource.php
+++ b/src/Resources/PermissionResource.php
@@ -30,7 +30,7 @@ class PermissionResource extends Resource
 {
     public static function isScopedToTenant(): bool
     {
-        return config('filament-spatie-roles-permissions.scope_to_tenant.permissions', true);
+        return config('filament-spatie-roles-permissions.scope_premissions_to_tenant', config('filament-spatie-roles-permissions.scope_to_tenant', true));
     }   
 
     public static function getNavigationIcon(): ?string

--- a/src/Resources/PermissionResource.php
+++ b/src/Resources/PermissionResource.php
@@ -30,7 +30,7 @@ class PermissionResource extends Resource
 {
     public static function isScopedToTenant(): bool
     {
-        return config('filament-spatie-roles-permissions.scope_to_tenant', true);
+        return config('filament-spatie-roles-permissions.scope_to_tenant.permissions', true);
     }   
 
     public static function getNavigationIcon(): ?string

--- a/src/Resources/RoleResource.php
+++ b/src/Resources/RoleResource.php
@@ -29,7 +29,7 @@ class RoleResource extends Resource
 
     public static function isScopedToTenant(): bool
     {
-        return config('filament-spatie-roles-permissions.scope_to_tenant', true);
+        return config('filament-spatie-roles-permissions.scope_to_tenant.roles', true);
     }
 
     public static function getNavigationIcon(): ?string

--- a/src/Resources/RoleResource.php
+++ b/src/Resources/RoleResource.php
@@ -29,7 +29,7 @@ class RoleResource extends Resource
 
     public static function isScopedToTenant(): bool
     {
-        return config('filament-spatie-roles-permissions.scope_to_tenant.roles', true);
+        return config('filament-spatie-roles-permissions.scope_roles_to_tenant', config('filament-spatie-roles-permissions.scope_to_tenant', true));
     }
 
     public static function getNavigationIcon(): ?string


### PR DESCRIPTION
This pull request refactors the existing **scope_to_tenant** functionality to separate the logic for handling roles and permissions. Previously, roles and permissions were treated together under a single scope, which created confusion and limited flexibility. By isolating the two, we aim to improve clarity and enable more granular control over tenant-specific roles and permissions management.