### PR TITLE
Fix GitHub Actions badge link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Latest Version on Packagist](https://img.shields.io/packagist/v/althinect/filament-spatie-roles-permissions.svg?style=flat-square)](https://packagist.org/packages/althinect/filament-spatie-roles-permissions)
 [![Total Downloads](https://img.shields.io/packagist/dt/althinect/filament-spatie-roles-permissions.svg?style=flat-square)](https://packagist.org/packages/althinect/filament-spatie-roles-permissions)
-[![GitHub Actions](https://github.com/althinect/filament-spatie-roles-permissions/actions/workflows/main.yml/badge.svg)](https://github.com/Althinect/enum-permission)
+[![GitHub Actions](https://github.com/althinect/filament-spatie-roles-permissions/actions/workflows/main.yml/badge.svg)](https://github.com/Althinect/filament-spatie-roles-permissions)
 
 This plugin is built on top of [Spatie's Permission](https://spatie.be/docs/laravel-permission/v6/introduction) package. 
 


### PR DESCRIPTION
Corrects the GitHub Actions badge link that was incorrectly pointing to `/enum-permission` instead of `/filament-spatie-roles-permissions`.

The badge image was correct but the link destination was wrong, causing users to be redirected to the wrong repository when clicking on the GitHub Actions badge.

**Changes:**
- Fixed GitHub Actions badge URL from `github.com/Althinect/enum-permission` to `github.com/Althinect/filament-spatie-roles-permissions`