### PR TITLE
bugfix/3.x-view-role-column-span

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,10 @@ Follow the instructions on [Filament Multi-tenancy](https://filamentphp.com/docs
 
 In the **filament-spatie-roles-permissions.php** config file, you can customize the permission generation
 
+If you are using a custom theme from a previous version of filament then there is a possibility that the layout 
+for the roles and permissions will not be full-width. 
+You can set the default column span to 'full' in the config to preserve the v3 default (full-width) layout.
+
 ## Security
 
 If you discover any security related issues, please create an issue.

--- a/config/filament-spatie-roles-permissions.php
+++ b/config/filament-spatie-roles-permissions.php
@@ -220,4 +220,14 @@ return [
 
         'policies_namespace' => 'App\Policies',
     ],
+    /**
+     * Implemented to allow customisation of the resource layout due to a change in Filament since v4
+     * If you have a custom theme and need to restore the layout to pre-Filament 4, set this to 'full'
+     * @see \Filament\Support\Concerns\CanSpanColumns::columnSpan
+     */
+    'layout' => [
+        'resources' => [
+            'default_section_column_span' => null
+        ]
+    ]
 ];

--- a/src/Resources/PermissionResource.php
+++ b/src/Resources/PermissionResource.php
@@ -108,7 +108,7 @@ class PermissionResource extends Resource
                                     }
                                 )
                                 ->preload(config('filament-spatie-roles-permissions.preload_roles', true)),
-                        ]),
+                        ])->columnSpan(['default' => config('filament-spatie-roles-permissions.layout.resources.default_section_column_span', null)]),
                     ]),
             ]);
     }

--- a/src/Resources/RoleResource.php
+++ b/src/Resources/RoleResource.php
@@ -120,7 +120,7 @@ class RoleResource extends Resource
                                     ->placeholder(__('filament-spatie-roles-permissions::filament-spatie.select-team'))
                                     ->hint(__('filament-spatie-roles-permissions::filament-spatie.select-team-hint')),
                             ]),
-                    ])->columnSpanFull(),
+                    ])->columnSpan(['default' => config('filament-spatie-roles-permissions.layout.resources.default_section_column_span', null)]),
             ]);
     }
 

--- a/src/Resources/RoleResource.php
+++ b/src/Resources/RoleResource.php
@@ -120,7 +120,7 @@ class RoleResource extends Resource
                                     ->placeholder(__('filament-spatie-roles-permissions::filament-spatie.select-team'))
                                     ->hint(__('filament-spatie-roles-permissions::filament-spatie.select-team-hint')),
                             ]),
-                    ]),
+                    ])->columnSpanFull(),
             ]);
     }
 


### PR DESCRIPTION
Make the container for the Roles form use columnSpanFull to ensure it spans the page even when using a custom theme.
