### PR TITLE
Fix 2.x navigation group return type

### DIFF
--- a/src/Resources/PermissionResource.php
+++ b/src/Resources/PermissionResource.php
@@ -55,7 +55,17 @@ class PermissionResource extends Resource
 
     public static function getNavigationGroup(): ?string
     {
-        return __(config('filament-spatie-roles-permissions.navigation_section_group', 'filament-spatie-roles-permissions::filament-spatie.section.roles_and_permissions'));
+        $navigationGroup = config('filament-spatie-roles-permissions.navigation_section_group', 'filament-spatie-roles-permissions::filament-spatie.section.roles_and_permissions');
+
+        if ($navigationGroup instanceof \BackedEnum) {
+            return (string) $navigationGroup->value;
+        }
+
+        if ($navigationGroup instanceof \UnitEnum) {
+            return $navigationGroup->name;
+        }
+
+        return __($navigationGroup);
     }
 
     public static function getNavigationSort(): ?int

--- a/src/Resources/RoleResource.php
+++ b/src/Resources/RoleResource.php
@@ -22,7 +22,6 @@ use Illuminate\Validation\Rules\Unique;
 use Spatie\Permission\Models\Role;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
-use UnitEnum;
 
 class RoleResource extends Resource
 {
@@ -53,13 +52,19 @@ class RoleResource extends Resource
         return __('filament-spatie-roles-permissions::filament-spatie.section.role');
     }
 
-    public static function getNavigationGroup(): UnitEnum|string|null
+    public static function getNavigationGroup(): ?string
     {
         $navigationGroup = config('filament-spatie-roles-permissions.navigation_section_group', 'filament-spatie-roles-permissions::filament-spatie.section.roles_and_permissions');
 
-        return $navigationGroup instanceof UnitEnum
-            ? $navigationGroup :
-            __($navigationGroup);
+        if ($navigationGroup instanceof \BackedEnum) {
+            return (string) $navigationGroup->value;
+        }
+
+        if ($navigationGroup instanceof \UnitEnum) {
+            return $navigationGroup->name;
+        }
+
+        return __($navigationGroup);
     }
 
     public static function getNavigationSort(): ?int


### PR DESCRIPTION
## Summary

This fixes the v2.3.3 fatal error in `RoleResource::getNavigationGroup()` by keeping the Filament 3-compatible `?string` return type while still supporting enum values configured for the navigation group.

The same enum-to-string handling is applied to `PermissionResource::getNavigationGroup()` for consistency.

## Context

- Fixes #258
- Replaces the closed attempt in #259 with a fresh branch against `2.x`
- Keeps the enum support introduced around #254 without widening the method return type beyond Filament 3

## Verification

- `php -l src/Resources/RoleResource.php`
- `php -l src/Resources/PermissionResource.php`
- `composer validate --no-check-publish --no-interaction`
- `git diff --check`

The `2.x` branch does not currently include a committed test suite or a PR workflow targeting `2.x`, so this PR keeps the change narrowly scoped to the resource methods.