### PR TITLE
Fix zh_TW translation

### DIFF
--- a/resources/lang/zh_TW/filament-spatie.php
+++ b/resources/lang/zh_TW/filament-spatie.php
@@ -27,6 +27,6 @@ return [
     'section.roles' => '角色',
     'section.roles_and_permissions' => '角色和權限',
     'select-team' => '選擇團隊',
-    'select-team-hint' => '保持空白為使用默認角色',
+    'select-team-hint' => '保持空白為使用全域角色',
     'section.users' => '使用者',
 ];


### PR DESCRIPTION
The "默認" is used in China, not Taiwan. The correct term is "預設".

However, the English is "global", not "default", so I change it to "全域" to match the English version.